### PR TITLE
change server url dynamically

### DIFF
--- a/utils/fetchData.ts
+++ b/utils/fetchData.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-const serverURL = "http://localhost:5000";
+const serverURL = process.env.NODE_ENV === 'production' ? 'https://travelbucket4300.herokuapp.com/' : "http://localhost:5000";
 
 export const fetchResults = async (searchCity: string) => {
     const result = await axios(


### PR DESCRIPTION
i redeployed the updated backend to heroku, so now if you do the same city search here https://travel-bucket-git-change-server-url-dynamically.foxhatleo.now.sh

it'll retrieve the information (currently just city name) from travelbucket4300.herokuapp.com instead of locally